### PR TITLE
Added an ability to change color of text and background color of widget.

### DIFF
--- a/awesompd.lua
+++ b/awesompd.lua
@@ -202,6 +202,8 @@ function awesompd:create()
 -- Default user options
    instance.servers = { { server = "localhost", port = 6600 } }
    instance.font = "Monospace"
+   instance.font_color = beautiful.fg_normal
+   instance.background = beautiful.bg_normal
    instance.scrolling = true
    instance.output_size = 30
    instance.update_interval = 10
@@ -843,9 +845,9 @@ function awesompd:notify_state(state_changed)
 end
 
 function awesompd:wrap_output(text)
-   return format('<span font="%s">%s%s%s</span>', 
-                 self.font, self.ldecorator, 
-                 awesompd.protect_string(text), self.rdecorator)
+   return format('<span background="%s" font="Terminus 12"> <span font="%s" color="%s" background = "%s">%s%s%s</span></span>',
+		self.background, self.font, self.font_color,self.background,self.ldecorator,
+		awesompd.protect_string(text), self.rdecorator)
 end
 
 function awesompd:mpcquery()

--- a/rcsample.lua
+++ b/rcsample.lua
@@ -85,6 +85,8 @@ mysystray = widget({ type = "systray" })
 
   musicwidget = awesompd:create() -- Create awesompd widget
   musicwidget.font = "Liberation Mono" -- Set widget font 
+--musicwidget.font_color = "#000000"	--Set widget font color
+--musicwidget.background = "#FFFFFF"	--Set widget background
   musicwidget.scrolling = true -- If true, the text in the widget will be scrolled
   musicwidget.output_size = 30 -- Set the size of widget in symbols
   musicwidget.update_interval = 10 -- Set the update interval in seconds


### PR DESCRIPTION
Thats how it looks on my Awesomebox:
![awesoMPD](https://f.cloud.github.com/assets/2613966/321727/05b6df84-9a07-11e2-861d-4b715748d9b6.png)
Usage:

``` lua
musicwidget.font_color = "#000000"  --Set font color to white
musicwidget.background = "#FFFFFF"  --Set background color to black
```

By default colors will be taken from beatiful theme. 'fg_normal' for font color and 'bg_normal' for background colour.
This feature should be useful.
If it is I will add the same to the awesome-git branch. 
